### PR TITLE
[Issue #9] Implementation of screen switching using RN stack navigator

### DIFF
--- a/App.js
+++ b/App.js
@@ -27,22 +27,22 @@ export default function App() {
     <NavigationContainer>
       <StatusBar />
       <Stack.Navigator 
-          initialRouteName={"onboarding"}
+          initialRouteName={"Onboarding"}
           screenOptions={{
             headerShown: false,
             headerBackVisible: false
           }}
           >
         <Stack.Screen
-          name="onboarding"
+          name="Onboarding"
           component={Onboarding}
         />
         <Stack.Screen
-          name="consent"
+          name="Consent"
           component={Consent}
         />
         <Stack.Screen
-          name="app"
+          name="App"
           component={Navigation}
         />
       </Stack.Navigator>

--- a/App.js
+++ b/App.js
@@ -9,6 +9,7 @@ import Navigation from "./components/Navigation";
 // Screen imports
 import Onboarding from "./screens/Onboarding";
 import Consent from "./screens/Consent";
+import { useState } from "react";
 
 // App
 export default function App() {
@@ -17,19 +18,24 @@ export default function App() {
     HammersmithOne: require("./assets/fonts/HammersmithOne-Regular.ttf"),
   });
 
+  const [isOnboarding, setIsOnboarding] = useState(true)
+  const [hasConsented, setHasConsented] = useState(false)
+
   if (!loaded) return null;
 
   return (
     <NavigationContainer>
       <StatusBar />
 
-      {/* <Onboarding /> */}
+      {/* Mutually exclusive to consent */}
+      {isOnboarding && <Onboarding onDone={setIsOnboarding}/>}
 
-      <Consent />
+      {/* Once onboarding is done and the user has not yet consented */}
+      {!hasConsented && !isOnboarding && <Consent onConsented={setHasConsented}/>}
 
-      {/* <Navigation /> */}
+      {/* Not onboarding and consented implies that the user can see the app */}
+      {!isOnboarding && hasConsented && <Navigation />}
 
-      {/* {onboardingDone ? <Navigation /> : <Onboarding />} */}
     </NavigationContainer>
   );
 }

--- a/App.js
+++ b/App.js
@@ -10,6 +10,7 @@ import Navigation from "./components/Navigation";
 import Onboarding from "./screens/Onboarding";
 import Consent from "./screens/Consent";
 import { useState } from "react";
+import { createNativeStackNavigator } from "@react-navigation/native-stack";
 
 // App
 export default function App() {
@@ -18,24 +19,33 @@ export default function App() {
     HammersmithOne: require("./assets/fonts/HammersmithOne-Regular.ttf"),
   });
 
-  const [isOnboarding, setIsOnboarding] = useState(true)
-  const [hasConsented, setHasConsented] = useState(false)
+  const Stack = createNativeStackNavigator()
 
   if (!loaded) return null;
 
   return (
     <NavigationContainer>
       <StatusBar />
-
-      {/* Mutually exclusive to consent */}
-      {isOnboarding && <Onboarding onDone={setIsOnboarding}/>}
-
-      {/* Once onboarding is done and the user has not yet consented */}
-      {!hasConsented && !isOnboarding && <Consent onConsented={setHasConsented}/>}
-
-      {/* Not onboarding and consented implies that the user can see the app */}
-      {!isOnboarding && hasConsented && <Navigation />}
-
+      <Stack.Navigator 
+          initialRouteName={"onboarding"}
+          screenOptions={{
+            headerShown: false,
+            headerBackVisible: false
+          }}
+          >
+        <Stack.Screen
+          name="onboarding"
+          component={Onboarding}
+        />
+        <Stack.Screen
+          name="consent"
+          component={Consent}
+        />
+        <Stack.Screen
+          name="app"
+          component={Navigation}
+        />
+      </Stack.Navigator>
     </NavigationContainer>
   );
 }

--- a/App.js
+++ b/App.js
@@ -1,16 +1,14 @@
-// import { useState } from "react";
 import { StatusBar } from "expo-status-bar";
 import { NavigationContainer } from "@react-navigation/native";
+import { createStackNavigator } from "@react-navigation/stack";
 import { useFonts } from "expo-font";
 
-// Component imorts
+// Component imports
 import Navigation from "./components/Navigation";
 
 // Screen imports
 import Onboarding from "./screens/Onboarding";
 import Consent from "./screens/Consent";
-import { useState } from "react";
-import { createNativeStackNavigator } from "@react-navigation/native-stack";
 
 // App
 export default function App() {
@@ -19,7 +17,7 @@ export default function App() {
     HammersmithOne: require("./assets/fonts/HammersmithOne-Regular.ttf"),
   });
 
-  const Stack = createNativeStackNavigator()
+  const Stack = createStackNavigator()
 
   if (!loaded) return null;
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "dependencies": {
     "@expo/vector-icons": "^13.0.0",
     "@react-navigation/bottom-tabs": "^6.4.0",
-    "@react-navigation/native": "*",
+    "@react-navigation/native": "^6.0.13",
+    "@react-navigation/native-stack": "^6.9.1",
     "@react-navigation/stack": "*",
     "expo": "~46.0.16",
     "expo-constants": "~13.2.4",

--- a/screens/Consent.js
+++ b/screens/Consent.js
@@ -3,7 +3,7 @@ import { StyleSheet, View, Text, Image, TouchableOpacity } from "react-native";
 import { assets, COLOURS } from "../constants";
 
 // Consent screen
-export default function Consent({ onConsented }) {
+export default function Consent({ navigation }) {
   const [modalOn, setModalOn] = useState(true);
   const [consent, setConsent] = useState(false);
 
@@ -15,7 +15,7 @@ export default function Consent({ onConsented }) {
     setModalOn((previousState) => !previousState);
     setConsent((previousState) => !previousState);
     setTimeout(() => {
-      onConsented(true);
+      navigation.navigate('app')
     }, 1000)
   };
 

--- a/screens/Consent.js
+++ b/screens/Consent.js
@@ -15,7 +15,7 @@ export default function Consent({ navigation }) {
     setModalOn((previousState) => !previousState);
     setConsent((previousState) => !previousState);
     setTimeout(() => {
-      navigation.navigate('app')
+      navigation.navigate('App')
     }, 1000)
   };
 

--- a/screens/Consent.js
+++ b/screens/Consent.js
@@ -3,7 +3,7 @@ import { StyleSheet, View, Text, Image, TouchableOpacity } from "react-native";
 import { assets, COLOURS } from "../constants";
 
 // Consent screen
-export default function Consent() {
+export default function Consent({ onConsented }) {
   const [modalOn, setModalOn] = useState(true);
   const [consent, setConsent] = useState(false);
 
@@ -14,8 +14,9 @@ export default function Consent() {
   const handleAccept = () => {
     setModalOn((previousState) => !previousState);
     setConsent((previousState) => !previousState);
-
-    // TimeOut (?) and Redirect to Main with the tab nav =>
+    setTimeout(() => {
+      onConsented(true);
+    }, 1000)
   };
 
   return (

--- a/screens/Onboarding.js
+++ b/screens/Onboarding.js
@@ -5,7 +5,7 @@ import { COLOURS, onboardingData } from "../constants";
 import { TouchableOpacity } from "react-native-gesture-handler";
 
 // Onboarding screen
-export default function Onboarding({ onDone }) {
+export default function Onboarding({ navigation }) {
   const renderItem = ({ item }) => {
     return (
       <View style={styles.slide}>
@@ -90,7 +90,7 @@ export default function Onboarding({ onDone }) {
   const renderDoneButton = () => {
     return (
       <TouchableOpacity
-        onPress={() => onDone(false)}
+        onPress={() => navigation.navigate('consent')}
         style={{
           ...styles.buttonWrapper,
           backgroundColor: COLOURS.primary,

--- a/screens/Onboarding.js
+++ b/screens/Onboarding.js
@@ -2,9 +2,10 @@ import AppIntroSlider from "react-native-app-intro-slider";
 
 import { View, Image, Text, StyleSheet } from "react-native";
 import { COLOURS, onboardingData } from "../constants";
+import { TouchableOpacity } from "react-native-gesture-handler";
 
 // Onboarding screen
-export default function Onboarding() {
+export default function Onboarding({ onDone }) {
   const renderItem = ({ item }) => {
     return (
       <View style={styles.slide}>
@@ -88,7 +89,8 @@ export default function Onboarding() {
 
   const renderDoneButton = () => {
     return (
-      <View
+      <TouchableOpacity
+        onPress={() => onDone(false)}
         style={{
           ...styles.buttonWrapper,
           backgroundColor: COLOURS.primary,
@@ -109,7 +111,7 @@ export default function Onboarding() {
         >
           Done
         </Text>
-      </View>
+      </TouchableOpacity>
     );
   };
 

--- a/screens/Onboarding.js
+++ b/screens/Onboarding.js
@@ -90,7 +90,7 @@ export default function Onboarding({ navigation }) {
   const renderDoneButton = () => {
     return (
       <TouchableOpacity
-        onPress={() => navigation.navigate('consent')}
+        onPress={() => navigation.navigate('Consent')}
         style={{
           ...styles.buttonWrapper,
           backgroundColor: COLOURS.primary,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1715,7 +1715,15 @@
   resolved "https://registry.yarnpkg.com/@react-navigation/elements/-/elements-1.3.6.tgz#fa700318528db93f05144b1be4b691b9c1dd1abe"
   integrity sha512-pNJ8R9JMga6SXOw6wGVN0tjmE6vegwPmJBL45SEMX2fqTfAk2ykDnlJHodRpHpAgsv0DaI8qX76z3A+aqKSU0w==
 
-"@react-navigation/native@*":
+"@react-navigation/native-stack@^6.9.1":
+  version "6.9.1"
+  resolved "https://registry.yarnpkg.com/@react-navigation/native-stack/-/native-stack-6.9.1.tgz#6013300e4cd0b33e242aa18593e4dff7db2ab3d1"
+  integrity sha512-aOuJP97ge6NRz8wH6sDKfLTfdygGmraYh0apKrrVbGvMnflbPX4kpjQiAQcUPUpMeas0betH/Su8QubNL8HEkg==
+  dependencies:
+    "@react-navigation/elements" "^1.3.6"
+    warn-once "^0.1.0"
+
+"@react-navigation/native@^6.0.13":
   version "6.0.13"
   resolved "https://registry.yarnpkg.com/@react-navigation/native/-/native-6.0.13.tgz#ec504120e193ea6a7f24ffa765a1338be5a3160a"
   integrity sha512-CwaJcAGbhv3p3ECablxBkw8QBCGDWXqVRwQ4QbelajNW623m3sNTC9dOF6kjp8au6Rg9B5e0KmeuY0xWbPk79A==


### PR DESCRIPTION
Current implementation includes:

- animation of sliding to the left when going from onboarding -> consent -> home screens
- header is hidden, but could be utilised later on